### PR TITLE
Generate accent palette dynamically from random hue

### DIFF
--- a/app/assets/scss/_tokens.scss
+++ b/app/assets/scss/_tokens.scss
@@ -3,9 +3,10 @@
 // Exposed as CSS custom properties (global).
 
 :root {
-  // Accent: one hot accent, locked per page load. A head script picks one of
-  // three palettes at random each refresh (see [data-accent] blocks below).
-  // Default (emerald) covers SSR / no-JS before the script runs.
+  // Accent: one hot accent, locked per page load. A head script (generateAccent
+  // in nuxt.config.ts) derives the whole accent palette from one random hue each
+  // refresh and writes these same --accent-* vars inline on <html>. The emerald
+  // values below are the SSR / no-JS fallback before that script runs.
   --accent: #0c7d54;        // fills, large marks, focus
   --accent-hover: #0a6644;  // interactive hover
   --accent-ink: #0a6644;    // accent as small text on paper (AA)
@@ -48,77 +49,4 @@
 
   // Motion
   --ease: cubic-bezier(0.16, 1, 0.3, 1);
-}
-
-// ── Random accent palettes (picked per page load by the head script) ──
-:root[data-accent='emerald'] {
-  --accent: #0c7d54;
-  --accent-hover: #0a6644;
-  --accent-ink: #0a6644;
-  --accent-tint: rgba(12, 125, 84, 0.09);
-  --accent-line: rgba(12, 125, 84, 0.30);
-  --on-accent: #f1faf6;
-}
-
-:root[data-accent='cobalt'] {
-  --accent: #2747ff;
-  --accent-hover: #1b35d6;
-  --accent-ink: #2236c2;
-  --accent-tint: rgba(39, 71, 255, 0.09);
-  --accent-line: rgba(39, 71, 255, 0.30);
-  --on-accent: #f2f4ff;
-}
-
-:root[data-accent='raspberry'] {
-  --accent: #d11e6a;
-  --accent-hover: #b01659;
-  --accent-ink: #a81457;
-  --accent-tint: rgba(209, 30, 106, 0.09);
-  --accent-line: rgba(209, 30, 106, 0.30);
-  --on-accent: #fff1f6;
-}
-
-:root[data-accent='teal'] {
-  --accent: #0a7077;
-  --accent-hover: #085c61;
-  --accent-ink: #085c61;
-  --accent-tint: rgba(10, 112, 119, 0.10);
-  --accent-line: rgba(10, 112, 119, 0.30);
-  --on-accent: #f0fafa;
-}
-
-:root[data-accent='violet'] {
-  --accent: #6d28d9;
-  --accent-hover: #5b1fb8;
-  --accent-ink: #5b1fb8;
-  --accent-tint: rgba(109, 40, 217, 0.09);
-  --accent-line: rgba(109, 40, 217, 0.30);
-  --on-accent: #f6f1fe;
-}
-
-:root[data-accent='crimson'] {
-  --accent: #c81e3c;
-  --accent-hover: #aa1733;
-  --accent-ink: #aa1733;
-  --accent-tint: rgba(200, 30, 60, 0.09);
-  --accent-line: rgba(200, 30, 60, 0.30);
-  --on-accent: #fff1f3;
-}
-
-:root[data-accent='amber'] {
-  --accent: #8a5c00;
-  --accent-hover: #6f4a00;
-  --accent-ink: #6f4a00;
-  --accent-tint: rgba(138, 92, 0, 0.10);
-  --accent-line: rgba(138, 92, 0, 0.32);
-  --on-accent: #fdf6e7;
-}
-
-:root[data-accent='indigo'] {
-  --accent: #3730a3;
-  --accent-hover: #2f2986;
-  --accent-ink: #2f2986;
-  --accent-tint: rgba(55, 48, 163, 0.09);
-  --accent-line: rgba(55, 48, 163, 0.30);
-  --on-accent: #f1f1fc;
 }

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,3 +1,56 @@
+// Runs in the browser before first paint (serialized via .toString() into an
+// inline <head> script). Picks one random hue and derives the whole accent
+// palette from it, so a new colour appears every refresh without hand-writing
+// per-colour CSS. Self-contained on purpose: no outer references survive
+// stringification. Mirrors the --accent-* tokens defined in _tokens.scss.
+function generateAccent() {
+  const root = document.documentElement
+  const hue = Math.floor(Math.random() * 360)
+  const sat = 70 // saturation %, fixed for a consistent vividness
+
+  // HSL -> [r, g, b] (0-255). lightness in %.
+  const rgb = (light: number): [number, number, number] => {
+    const s = sat / 100
+    const l = light / 100
+    const a = s * Math.min(l, 1 - l)
+    const f = (n: number) => {
+      const k = (n + hue / 30) % 12
+      return 255 * (l - a * Math.max(-1, Math.min(k - 3, 9 - k, 1)))
+    }
+    return [f(0), f(8), f(4)]
+  }
+
+  // WCAG relative luminance of an [r, g, b] triple.
+  const lum = (c: number[]) =>
+    c
+      .map((v) => {
+        const x = v / 255
+        return x <= 0.03928 ? x / 12.92 : Math.pow((x + 0.055) / 1.055, 2.4)
+      })
+      .reduce((sum, x, i) => sum + x * [0.2126, 0.7152, 0.0722][i], 0)
+
+  const contrastWithWhite = (c: number[]) => 1.05 / (lum(c) + 0.05)
+
+  // Darken the accent (hue-aware) until white text on it clears WCAG AA, so
+  // yellows/greens get pushed dark enough instead of washing out.
+  let light = 52
+  while (light > 22 && contrastWithWhite(rgb(light)) < 4.6) light -= 1
+
+  const css = (c: [number, number, number]) =>
+    `rgb(${c.map(Math.round).join(' ')})`
+  const rgba = (c: [number, number, number], alpha: number) =>
+    `rgb(${c.map(Math.round).join(' ')} / ${alpha})`
+
+  const accent = rgb(light)
+  const set = (name: string, value: string) => root.style.setProperty(name, value)
+  set('--accent', css(accent))
+  set('--accent-hover', css(rgb(light - 8)))
+  set('--accent-ink', css(rgb(light - 2)))
+  set('--accent-tint', rgba(accent, 0.09))
+  set('--accent-line', rgba(accent, 0.3))
+  set('--on-accent', css(rgb(97))) // hue-tinted near-white text on fills
+}
+
 // https://nuxt.com/docs/api/configuration/nuxt-config
 export default defineNuxtConfig({
   compatibilityDate: '2025-01-01',
@@ -12,13 +65,15 @@ export default defineNuxtConfig({
       ],
       script: [
         // Mark JS-available before first paint so scroll-reveal only hides
-        // content when JS can reveal it (no-JS users see everything). Also pick
-        // a random accent palette per load (no flash: runs before body paint).
+        // content when JS can reveal it (no-JS users see everything). Then
+        // generate a fresh accent palette from a single random hue and write
+        // every --accent-* token inline on <html> (no flash: runs before body
+        // paint; the :root defaults cover SSR / no-JS). See generateAccent().
         {
           innerHTML:
-            "document.documentElement.classList.add('js');" +
-            "(function(){var a=['emerald','cobalt','raspberry','teal','violet','crimson','amber','indigo'];" +
-            "document.documentElement.dataset.accent=a[Math.floor(Math.random()*a.length)]})()",
+            "document.documentElement.classList.add('js');(" +
+            generateAccent.toString() +
+            ')()',
           tagPosition: 'head',
         },
       ],


### PR DESCRIPTION
## Summary
Replaced the static, hand-written accent color palettes with a dynamic system that generates a complete accent palette from a single random hue on each page load. This eliminates the need to maintain multiple pre-defined color schemes while providing infinite color variety.

## Key Changes
- **Removed static palette definitions** from `_tokens.scss`: Deleted 8 pre-defined `[data-accent]` color schemes (emerald, cobalt, raspberry, teal, violet, crimson, amber, indigo)
- **Added `generateAccent()` function** in `nuxt.config.ts`: A self-contained script that:
  - Picks a random hue (0-360°) on each page load
  - Derives all accent token values (--accent, --accent-hover, --accent-ink, --accent-tint, --accent-line, --on-accent) from that single hue
  - Applies WCAG AA contrast validation to ensure white text on accent fills remains readable, automatically darkening yellows/greens as needed
  - Writes all computed values inline to the `<html>` element before first paint
- **Updated inline head script** in `nuxt.config.ts`: Changed from selecting a random palette name to executing the `generateAccent()` function directly

## Implementation Details
- The `generateAccent()` function is self-contained with no external dependencies, allowing it to be serialized via `.toString()` into an inline `<head>` script
- Uses HSL color space for hue-aware palette generation, converting to RGB for CSS output
- Implements proper WCAG relative luminance calculation to ensure accessible contrast ratios
- Maintains the same CSS custom property names and fallback values in `:root` for SSR and no-JS scenarios
- No flash of unstyled content: script runs before body paint with all tokens set inline

https://claude.ai/code/session_016QQ2mscPkhv7dFGxd4XJeu